### PR TITLE
If there are errors from execute still display any data

### DIFF
--- a/src/utils/strawberry.js
+++ b/src/utils/strawberry.js
@@ -86,18 +86,18 @@ export const useStrawberry = (data) => {
 
         // check errors
         if (results.errors) {
-          state.results = null;
           const errors = results.errors.toJs();
           state.errors = errors.map((e) => e.__str__()).join("\n");
-          results.destroy();
-          return;
         }
 
         // store results
-        const result = results.data.toJs({
-          dict_converter: Object.fromEntries,
-        });
-        state.results = JSON.stringify(result, null, 2);
+        if (results.data) {
+          const result = results.data.toJs({
+            dict_converter: Object.fromEntries,
+          });
+          state.results = JSON.stringify(result, null, 2);
+        }
+
         results.destroy();
       },
       { immediate: true, deep: true }


### PR DESCRIPTION
## Description

`schema.execute` can return errors and data. At the moment if there are any errors in the execute result then the app just discards any data. This PR changes this behaviour so that errors and data can be shown at the same time.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
